### PR TITLE
Update tox to perform pep8 checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ commands = pyflakes modules setup.py
 
 [testenv:pep8]
 deps = pep8
-commands = pep8 --count --repeat --show-source --exclude=.tox setup.py
+commands = pep8 modules --count --repeat --show-source --exclude=.tox setup.py
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
I noticed that unless the sub-folder is supplied to the pep8 command, it does not perform any pep8 checks on the files.
