### PR TITLE
Correct deb name for puppetlabs package in Ubuntu

### DIFF
--- a/install_puppet.sh
+++ b/install_puppet.sh
@@ -196,7 +196,7 @@ Pin: version $FACTER_VERSION
 Pin-Priority: 501
 EOF
 
-    puppet_deb=puppetlabs-release-${lsbdistcodename}.deb
+    puppet_deb=puppetlabs-release-pc1-${lsbdistcodename}.deb
     wget http://apt.puppetlabs.com/$puppet_deb -O $puppet_deb
     dpkg -i $puppet_deb
     rm $puppet_deb


### PR DESCRIPTION
My installation is failing because puppetlabs-release-vivid.deb is missing from apt.puppetlabs.com. It hosts a puppetlabs-release-pc1-vivid.deb file instead. Files with "pc1" in name is hosted for all the available releases there.
